### PR TITLE
Inclusion of AssemblyInfos.fs to the project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,4 +185,3 @@ docsrc/content/release-notes.md
 docsrc/tools/FSharp.Formatting.svclog
 
 /docs
-AssemblyInfo.fs

--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -144,11 +144,12 @@
         <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
         <AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
+        <CopyLocal>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[5])</CopyLocal>
       </PaketReferencesFileLinesInfo>
       <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
         <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
         <PrivateAssets Condition=" ('%(PaketReferencesFileLinesInfo.AllPrivateAssets)' == 'true') Or ('$(PackAsTool)' == 'true') ">All</PrivateAssets>
-        <ExcludeAssets Condition="%(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
+        <ExcludeAssets Condition="%(PaketReferencesFileLinesInfo.CopyLocal) == 'false'">runtime</ExcludeAssets>
         <Publish Condition=" '$(PackAsTool)' == 'true' ">true</Publish>
       </PackageReference>
     </ItemGroup>

--- a/src/FSharp.Plotly.WPF/FSharp.Plotly.WPF.fsproj
+++ b/src/FSharp.Plotly.WPF/FSharp.Plotly.WPF.fsproj
@@ -14,6 +14,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
     <Compile Include="ViewContainer.fs" />
     <Compile Include="ChartWPF.fs" />
     <None Include="WpfTest.fsx" />

--- a/src/FSharp.Plotly/FSharp.Plotly.fsproj
+++ b/src/FSharp.Plotly/FSharp.Plotly.fsproj
@@ -14,6 +14,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
     <Compile Include="StyleParams.fs" />
     <Compile Include="DynamicObj.fs" />
     <Compile Include="Colors.fs" />


### PR DESCRIPTION
This fixes the problem of incorrect assembly versions in the compiled DLLs.